### PR TITLE
Reader/Writer should implement Close() to free convertor

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -5,6 +5,7 @@ import (
 	"syscall"
 )
 
+// This implements io.ReadCloser interface
 type Reader struct {
 	source            io.Reader
 	converter         *Converter
@@ -59,6 +60,11 @@ func (this *Reader) fillBuffer() {
 	if err != nil {
 		this.err = err
 	}
+}
+
+// Must be called to free memory
+func (this *Reader) Close() error {
+	return this.converter.Close()
 }
 
 // implement the io.Reader interface

--- a/writer.go
+++ b/writer.go
@@ -2,6 +2,7 @@ package iconv
 
 import "io"
 
+// This implements io.WriteCloser interface
 type Writer struct {
 	destination       io.Writer
 	converter         *Converter
@@ -56,6 +57,11 @@ func (this *Writer) emptyBuffer() {
 	if err != nil {
 		this.err = err
 	}
+}
+
+// Must be called to free memory
+func (this *Writer) Close() error {
+	return this.converter.Close()
 }
 
 // implement the io.Writer interface


### PR DESCRIPTION
The internal Convertor should be freed.
