### PR TITLE
Move package to go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/djimenez/iconv-go
+
+go 1.24.0


### PR DESCRIPTION
Basically this package is very old (but still very useful!), and it doesn't use go-modules (a standard way that go manages dependencies nowadays). This can cause other go-programs, that use this package, to fail on compile time:
```
make build
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -o .build/api ./cmd/api
# github.com/djimenez/iconv-go
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/reader.go:10:21: undefined: Converter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/reader.go:18:20: undefined: NewConverter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/reader.go:28:58: undefined: Converter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/writer.go:7:21: undefined: Converter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/writer.go:15:20: undefined: NewConverter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/writer.go:25:63: undefined: Converter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/iconv.go:11:20: undefined: NewConverter
../../../go/pkg/mod/github.com/djimenez/iconv-go@v0.0.0-20160305225143-8960e66bd3da/iconv.go:37:20: undefined: NewConverter
make: *** [Makefile:17: build] Error 1
```

The error persists even if using `vendor` directory. I just added a `go.mod` file and fixed go version at `1.24.0` (currently the most up-to-date one).